### PR TITLE
Recreate CLAUDE.md with progressive disclosure

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -1,0 +1,280 @@
+# Architectural Patterns
+
+This document describes the architectural patterns, design decisions, and conventions used throughout the codebase.
+
+## Content Collection Pattern
+
+**Location**: `src/content/`, `src/schema/`, `src/content/config.ts`
+
+The site uses Astro's content collections for type-safe content management:
+
+1. **Schema Definition** (`src/schema/*.ts`):
+   - Each collection has a Zod schema defining frontmatter structure
+   - Example: `src/schema/journal.ts:4-40` - defines required/optional fields, enums for tags
+   - Schemas provide compile-time type safety and runtime validation
+
+2. **Collection Registration** (`src/content/config.ts:1-7`):
+   - Imports schemas and exports collection configuration
+   - Collections: `journal`, `haiku`, `projects`
+
+3. **Content Organization**:
+   - Journal: Year-based folders (`src/content/journal/YYYY/`)
+   - Each collection type has its own directory under `src/content/`
+
+**Benefits**: TypeScript inference, validation, autocomplete for frontmatter fields.
+
+## Remark Plugin Pattern
+
+**Location**: `src/utils/remark-*.ts`, `astro.config.mjs:27-29`
+
+Custom remark plugins extend MDX processing to inject computed data into frontmatter:
+
+1. **Plugin Structure** (see `src/utils/remark-reading-time.ts:6-13`):
+   ```typescript
+   export const remarkPlugin = () => {
+     return function (tree: Node, { data }: { data: any }) {
+       // Process AST
+       // Inject into data.astro.frontmatter
+     }
+   }
+   ```
+
+2. **Registration** (`astro.config.mjs:27-29`):
+   - Plugins registered in MDX integration config
+   - Execute during build time, before component rendering
+
+3. **Examples**:
+   - `remark-reading-time.ts` - Calculates reading time from content
+   - `remark-widont.ts` - Prevents widow words in titles
+
+**Benefits**: Computed frontmatter data available in templates without runtime calculation.
+
+## Component Mapping Pattern
+
+**Location**: `src/mdx-components.ts`, MDX integration
+
+HTML elements are mapped to custom Astro components for consistent styling and behavior:
+
+1. **Mapping Object** (`src/mdx-components.ts:39-80`):
+   - Maps HTML elements (a, blockquote, h1-h6, img, etc.) to custom components
+   - Makes custom components available in MDX without imports
+   - Example: `h2: Headline`, `a: TextLink`, `img: MarkdownImage`
+
+2. **Component Usage**:
+   - Standard markdown syntax automatically uses custom components
+   - Custom components can be used directly in MDX (YouTube, Banner, Figure, etc.)
+
+3. **Design Pattern**:
+   - Components receive standard HTML props
+   - Apply consistent Tailwind classes and behavior
+   - Example: All links use `TextLink` component for consistent styling
+
+**Benefits**: Consistent styling, enhanced functionality, no import boilerplate in content files.
+
+## Utility Function Pattern
+
+**Location**: `src/utils/`
+
+Pure functions for data transformation, following functional programming principles:
+
+1. **Content Filtering** (`src/utils/format-posts.ts:5-60`):
+   - `formatPosts()` - Filters, sorts, and limits posts
+   - Configurable options: removeDrafts, removeFuture, showFeatured, sortBy, limit
+   - Pure function: doesn't mutate input array
+
+2. **Sorting Functions**:
+   - `sort-by-date.ts` - Sorts by date field
+   - `sort-by-alphabet.ts` - Alphabetical sorting
+   - `sort-by-sortkey.ts` - Custom sort key field
+   - All return -1/0/1 for Array.sort() compatibility
+
+3. **Data Transformation**:
+   - `date.ts` - Date formatting utilities (ISO, display formats)
+   - `word-count.ts` - Text statistics
+   - `titlecase.ts` - Typography utilities
+
+**Principles**:
+- Pure functions (no side effects)
+- Single responsibility
+- Composable (see `format-posts.ts` using `sortByDate`, `sortByAlphabet`)
+- Easily testable
+
+## Layout Hierarchy Pattern
+
+**Location**: `src/layouts/`
+
+Layouts follow a composition pattern with a base layout and specialized variants:
+
+1. **Base Layout** (`src/layouts/BaseLayout.astro`):
+   - Core HTML structure, SEO setup, global styles
+   - Props interface at line 15-23
+   - Includes: header, footer, modals (search, menu)
+   - Handles: View transitions, theme provider, service worker registration
+
+2. **Specialized Layouts**:
+   - `PageLayout.astro` - Standard content pages
+   - `GridLayout.astro` - Grid-based layouts
+   - `AboutLayout.astro` - About page specific layout
+
+3. **Composition**:
+   - Specialized layouts import and wrap BaseLayout
+   - Add specific structure/styling without duplicating base functionality
+   - Use Astro's slot system for content injection
+
+**Benefits**: DRY principle, consistent global features, easy to extend.
+
+## Asset Generation Pipeline
+
+**Location**: Root `*.cjs` scripts
+
+Separate build scripts generate optimized assets from source files:
+
+1. **Script Types**:
+   - `og-generate.cjs` - Generates Open Graph preview images for posts
+   - `thumbnail-generate.cjs` - Creates thumbnail images
+   - `icons-generate.cjs` - Converts SVG icons to React/Preact components
+   - `convert-images.cjs` - Batch image format conversion (WebP)
+
+2. **Execution**:
+   - Run manually via npm scripts: `pnpm og:generate`, `pnpm icons:generate`
+   - `pnpm images` - Runs multiple generators in sequence
+   - Not part of main build pipeline (run when content/assets change)
+
+3. **Pattern**:
+   - Source files (SVG, images) in project
+   - Scripts read source → process → write to `public/` or `src/`
+   - Generated files committed to repo (for build reproducibility)
+
+**Benefits**: Optimized assets, consistent sizing, automated component generation.
+
+## Progressive Enhancement Pattern
+
+**Location**: `astro.config.mjs:58-81`, `src/layouts/BaseLayout.astro:146-149`
+
+The site progressively enhances from static HTML to dynamic functionality:
+
+1. **Service Worker** (`astro.config.mjs:58-81`):
+   - Caches fonts (woff2) for instant loading
+   - Runtime caching for images (CacheFirst strategy)
+   - 1-year expiration, 50 image limit
+
+2. **JavaScript Detection** (`BaseLayout.astro:146-149`):
+   - HTML starts with `class="no-js"`
+   - Script immediately swaps to `class="js"`
+   - CSS can target `.no-js` vs `.js` for fallbacks
+
+3. **View Transitions** (`astro.config.mjs:18`, `BaseLayout.astro:150`):
+   - Opt-in smooth page transitions
+   - Fallback to standard navigation
+
+**Benefits**: Works without JS, enhances with JS, offline capability.
+
+## Type Safety Pattern
+
+**Location**: Throughout TypeScript files
+
+Strong typing enforced via TypeScript strict mode and Zod schemas:
+
+1. **Content Types**:
+   - `CollectionEntry<'journal'>` - Type from schema
+   - Example: `src/pages/[...slug].astro:2-3`
+   - Autocomplete for frontmatter fields
+
+2. **Component Props**:
+   - Explicit interfaces: `BaseLayout.astro:15-23`
+   - Optional vs required fields
+   - Default values in destructuring
+
+3. **Utility Functions**:
+   - Typed parameters and return values
+   - Generic types where appropriate
+   - Example: `formatPosts()` takes `CollectionEntry<'journal'>[]`
+
+4. **Schema Validation**:
+   - Zod schemas in `src/schema/*.ts`
+   - Runtime validation + TypeScript types
+   - Enums for constrained values (tags, etc.)
+
+**Benefits**: Catch errors at compile time, better IDE support, self-documenting code.
+
+## Styling Conventions
+
+**Location**: `tailwind.config.cjs`, component files
+
+Tailwind CSS with extensive customization and logical properties:
+
+1. **Custom Scale** (`tailwind.config.cjs`):
+   - Spacing: Fluid sizing with clamp() (lines 95-123)
+   - Typography: Responsive font sizes (lines 128-139)
+   - Color system: Custom "shibui" palette (lines 16-36)
+
+2. **Plugins**:
+   - `tailwindcss-logical` - Logical properties (inline-start vs left)
+   - `tailwindcss-opentype` - OpenType font features
+   - See `tailwind.config.cjs:159-162`
+
+3. **Dark Mode**:
+   - Class-based strategy: `dark:` prefix
+   - See `tailwind.config.cjs:4`
+   - ThemeProvider component manages theme switching
+
+4. **Component Styling**:
+   - Utility-first approach
+   - Consistent spacing via custom scale
+   - Semantic class names where needed
+
+**Conventions**:
+- Use logical properties (mbe, mbs, pis, pie vs margin-bottom, margin-top, etc.)
+- Leverage custom spacing scale for consistency
+- Dark mode variants for all color-related styles
+
+## File-Based Routing Pattern
+
+**Location**: `src/pages/`
+
+Astro's file-based routing with static path generation:
+
+1. **Static Routes**:
+   - `index.astro` → `/`
+   - `about.mdx` → `/about/`
+   - `journal.astro` → `/journal/`
+
+2. **Dynamic Routes** (`src/pages/[...slug].astro`):
+   - `getStaticPaths()` at line 23-38
+   - Fetches all journal entries
+   - Returns array of { params, props }
+   - Each entry becomes a static page at build time
+
+3. **Nested Routes**:
+   - Directories create path segments
+   - `pages/tag/[tag].astro` → `/tag/:tag/`
+   - `pages/haiku/[...slug].astro` → `/haiku/:slug/`
+
+4. **Props Passing**:
+   - `getStaticPaths()` returns props (entry, prev, next)
+   - Available in component via `Astro.props`
+   - Enables pagination, related content, etc.
+
+**Benefits**: Static generation (fast), predictable URLs, simple pagination.
+
+## Data-Driven Content Pattern
+
+**Location**: `src/data/`, component imports
+
+Static data organized in JSON/TS files for easy updates:
+
+1. **Site Configuration** (`src/data/site.ts`):
+   - Centralized site metadata
+   - Imported in layouts, components
+   - Single source of truth
+
+2. **Navigation** (`src/data/navigation.json`, `subnavigation.json`):
+   - Declarative navigation structure
+   - Consumed by navigation components
+   - Easy to update without touching component code
+
+3. **Content Data** (`src/data/colors-japan.json`):
+   - Large datasets separate from code
+   - Used by specific pages (traditional-colors-of-japan.astro)
+
+**Benefits**: Content updates without code changes, reusable data, easier testing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,166 +1,137 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
-Personal website for Stefan Imhoff built with Astro, Preact, and Tailwind CSS. The site features a journal (blog), haiku collection, and project showcase with full-text search via Pagefind.
+Personal website and blog for Stefan Imhoff, featuring journal posts, haiku collection, project showcase, and full-text search. Built with Astro for static generation, Preact for interactive components, and styled with Tailwind CSS.
+
+**Live Site**: https://www.stefanimhoff.de
+
+## Tech Stack
+
+- **Framework**: Astro 4.x (static site generator with view transitions)
+- **UI Libraries**: Preact (React compatibility mode), MDX for content
+- **Styling**: Tailwind CSS with custom plugins (tailwindcss-logical, tailwindcss-opentype)
+- **Search**: Pagefind (full-text search)
+- **Package Manager**: pnpm
+- **Build Tools**: Vite, TypeScript (strict mode)
+- **Quality Tools**: ESLint, Prettier, Husky pre-commit hooks
+
+## Key Directories
+
+```
+src/
+├── components/     # Reusable UI components (Astro/Preact)
+├── content/        # Content collections (journal/, haiku/, projects/)
+├── schema/         # Zod schemas for content validation (src/schema/*.ts)
+├── layouts/        # Page templates (BaseLayout → specialized layouts)
+├── pages/          # File-based routing + dynamic [...slug].astro
+├── utils/          # Pure functions (formatPosts, sortByDate, remark plugins)
+├── data/           # Site config, navigation, colors (src/data/site.ts)
+├── icons/          # SVG icons (generated from source via icons:generate)
+├── styles/         # Global CSS
+└── text/           # Static page content
+
+Root scripts: *.cjs files for asset generation (OG images, thumbnails, icons)
+```
+
+## Essential Commands
+
+### Development
+```sh
+pnpm dev            # Start dev server
+pnpm build          # Build for production
+pnpm preview        # Build + preview production build
+```
+
+### Content Generation
+```sh
+pnpm plop           # Create new journal post (interactive)
+pnpm images         # Generate all images (OG + thumbnails)
+pnpm icons:generate # Convert SVG icons to components
+```
+
+### Code Quality
+```sh
+npx prettier --write <files>
+npx eslint --fix <files>
+npx lint-staged     # Run pre-commit hooks manually
+```
 
 ## Git Workflow
 
-**IMPORTANT**: The `master` branch is protected against direct pushes. Always create a new feature branch for any changes:
+**CRITICAL**: The `master` branch is protected. Always work on feature branches:
 
 ```sh
 git checkout -b feature/your-feature-name
-# Make changes, commit, then push
+# Make changes, commit
 git push -u origin feature/your-feature-name
 ```
 
 ### Commit Messages
-
-Always use [Conventional Commits](https://www.conventionalcommits.org/) format:
-
+Use [Conventional Commits](https://www.conventionalcommits.org/):
 - `feat:` - New feature
 - `fix:` - Bug fix
-- `docs:` - Documentation changes
-- `chore:` - Maintenance tasks
+- `docs:` - Documentation
 - `refactor:` - Code refactoring
-- `test:` - Test updates
-- `style:` - Code style/formatting changes
+- `style:` - Formatting
+- `test:` - Tests
+- `chore:` - Maintenance
 
-### Creating Pull Requests
-
-After pushing, create a pull request using `gh` CLI with the following requirements:
-
-- Assign to `@me`
-- Add one of the existing labels: `bug`, `documentation`, `enhancement`, or `maintenance`
-
+### Pull Requests
+Create PRs with assignment and labels:
 ```sh
-gh pr create --title "Your PR title" --body "Description" --assignee @me --label <label-name>
+gh pr create --title "Title" --body "Description" --assignee @me --label <bug|documentation|enhancement|maintenance>
 ```
 
-## Common Commands
+## Content Collections
 
-### Development
+Three typed collections defined in `src/content/config.ts`:
 
-```sh
-pnpm dev        # Start dev server
-pnpm start      # Alias for dev
-pnpm build      # Build for production
-pnpm preview    # Preview production build (runs build first)
-```
+1. **journal** (`src/content/journal/YYYY/*.mdx`)
+   - Schema: `src/schema/journal.ts`
+   - Required: title, date, tags (predefined enum)
+   - Optional: subtitle, description, cover, series, featured, draft
 
-### Code Quality
+2. **haiku** (`src/content/haiku/*.mdx`)
+   - Schema: `src/schema/haiku.ts`
+   - Minimal frontmatter (title, date)
 
-```sh
-npx prettier --write <files>  # Format files
-npx eslint --fix <files>      # Lint and fix files
-npx lint-staged               # Run pre-commit hooks manually
-```
+3. **projects** (`src/content/projects/*.mdx`)
+   - Schema: `src/schema/projects.ts`
+   - Includes project metadata (URL, sortkey, etc.)
 
-### Content Generation
+All schemas use Zod for type validation.
 
-```sh
-pnpm plop                     # Create new journal post (interactive)
-pnpm images                   # Generate OG images and thumbnails
-pnpm og:generate              # Generate Open Graph images
-pnpm thumbnail:generate       # Generate thumbnails
-pnpm icons:generate           # Generate icon components from SVG
-pnpm webp                     # Convert images to WebP format
-```
+## Key Files
 
-## Architecture
+- `astro.config.mjs` - Astro configuration, integrations (line 26-82)
+- `tailwind.config.cjs` - Custom Tailwind theme (colors, spacing, typography)
+- `src/mdx-components.ts` - Maps HTML elements to custom components (line 39-80)
+- `src/utils/format-posts.ts` - Content filtering/sorting logic
+- `src/utils/remark-reading-time.ts` - Reading time calculation plugin
+- `src/utils/remark-widont.ts` - Typography widow prevention
+- `src/pages/[...slug].astro` - Dynamic route handler for journal posts
 
-### Content Collections
+## Build Features
 
-Three content collections defined in `src/content/config.ts`, with schemas in `src/schema/`:
+Configured in `astro.config.mjs:26-82`:
+- MDX with custom remark plugins (reading time, widont)
+- Pagefind integration for search
+- Service worker (caches fonts/images)
+- Sitemap generation (excludes /cv/, /imprint/)
+- Web manifest for PWA support
+- View transitions
 
-- **journal**: Blog posts organized by year in `src/content/journal/YYYY/`
-- **haiku**: Haiku poems in `src/content/haiku/`
-- **projects**: Project descriptions in `src/content/projects/`
+## Additional Documentation
 
-Each collection has a Zod schema defining frontmatter structure (title, date, tags, etc.)
-
-### Pages & Routing
-
-Pages are in `src/pages/` using Astro's file-based routing:
-
-- Static pages: `index.astro`, `about.mdx`, `cv.astro`, `tools.mdx`, etc.
-- Dynamic routes: `[...slug].astro` for individual posts
-- RSS feeds: `rss.xml.js` and `rss-haiku.xml.js`
-
-### Components & Layouts
-
-- **Layouts**: `src/layouts/` - Page templates
-- **Components**: `src/components/` - Reusable UI components (Astro/Preact)
-- **Icons**: `src/icons/` - SVG icons, generate components with `pnpm icons:generate`
-
-### Styling
-
-Tailwind CSS with custom plugins:
-
-- `tailwindcss-logical` for logical properties
-- `tailwindcss-opentype` for OpenType features
-- Configuration in `tailwind.config.cjs`
-- Global styles in `src/styles/`
-
-### Utilities & Data
-
-- **Utils**: `src/utils/` - Helper functions including:
-  - `remark-reading-time.ts` - Adds reading time to posts
-  - `remark-widont.ts` - Prevents widows in titles
-  - `format-posts.ts`, `sort-by-date.ts`, etc.
-- **Data**: `src/data/` - Site metadata, navigation, colors
-- **Text**: `src/text/` - Static content for pages
-
-### Build Features
-
-Astro integrations configured in `astro.config.mjs`:
-
-- MDX support with custom remark plugins
-- Pagefind for full-text search
-- Service worker for offline support (fonts and images)
-- Automatic sitemap generation (excludes /cv/ and /imprint/)
-- Web manifest generation
-
-### Image Generation Scripts
-
-Root-level `.cjs` scripts for asset generation:
-
-- `og-generate.cjs` - Creates Open Graph images
-- `thumbnail-generate.cjs` - Generates post thumbnails
-- `icons-generate.cjs` - Converts SVGs to React components
-- `convert-images.cjs` - Batch image format conversion
-
-## Creating Content
-
-### New Journal Post
-
-Use Plop for consistent post structure:
-
-```sh
-pnpm plop
-```
-
-This creates a new post in `src/content/journal/YYYY/` with proper frontmatter, including predefined tag options (book, code, design, film, philosophy, poetry, politics, productivity, self-improvement, software, technology, writing).
-
-### Post Structure
-
-Journal posts require:
-
-- `title` (required)
-- `date` (required)
-- `description` (optional but recommended)
-- `tags` (array of predefined tags)
-- `draft` (boolean, defaults to false)
-- `featured` (boolean, optional)
-- `cover` (optional image path)
+Detailed architectural patterns and conventions:
+- `.claude/docs/architectural_patterns.md` - Design patterns, conventions, architecture decisions
 
 ## Development Notes
 
-- Site URL: https://www.stefanimhoff.de
-- Uses pnpm as package manager
-- Husky pre-commit hooks run lint-staged (Prettier + ESLint)
-- Custom Shiki theme defined in `shiki-theme.json`
-- TypeScript with strict null checks enabled
-- React JSX mode for Preact compatibility
+- Journal posts organized by year: `src/content/journal/YYYY/`
+- Tags are constrained by enum in `src/schema/journal.ts:15-34`
+- Custom Shiki syntax theme: `shiki-theme.json`
+- Asset generation scripts use CommonJS (*.cjs)
+- Service worker configured in `astro.config.mjs:58-81`
+- Dark mode via Tailwind's `class` strategy (see `tailwind.config.cjs:4`)


### PR DESCRIPTION
## Summary

Recreated CLAUDE.md following progressive disclosure principles to make it more concise and maintainable:

- **Reduced from verbose to 137 lines** (under the 150 line target)
- **Restructured around WHAT, WHY, HOW**: Tech stack, purpose, and essential commands
- **Removed code snippets**: Now uses file:line references instead
- **Removed formatting guidelines**: Assumes linters handle code style
- **Extracted architectural patterns**: Created `.claude/docs/architectural_patterns.md` with 11 detailed patterns

## New Structure

### CLAUDE.md
- Project overview and tech stack
- Key directories with purposes
- Essential commands (dev, build, content generation)
- Git workflow (kept as it's critical)
- Content collections overview
- References to additional documentation

### .claude/docs/architectural_patterns.md
Documents 11 architectural patterns observed across the codebase:
- Content Collection Pattern
- Remark Plugin Pattern
- Component Mapping Pattern
- Utility Function Pattern
- Layout Hierarchy Pattern
- Asset Generation Pipeline
- Progressive Enhancement Pattern
- Type Safety Pattern
- Styling Conventions
- File-Based Routing Pattern
- Data-Driven Content Pattern

## Benefits

- Easier to maintain (focused on universals, not specifics)
- Better progressive disclosure (quick overview → detailed patterns)
- More scannable for quick reference
- Patterns documented separately for deeper understanding