### PR TITLE
fix(essay): correct image caption and alt text in agentic note-taking essay

### DIFF
--- a/src/content/journal/2026/agentic-note-taking-obsidian-claude-code.mdx
+++ b/src/content/journal/2026/agentic-note-taking-obsidian-claude-code.mdx
@@ -92,9 +92,9 @@ I started with Claude Code and the `/init` command to teach Claude the structure
 Next, I taught Claude Code to use the `qmd` and `obsidian` commands to manage my vault. The `qmd` command enables Claude Code to search for notes in my vault using the QMD search engine, which is significantly faster than the built-in Obsidian search. The `obsidian` command allows Claude Code to create, edit, and delete notes in my vault. I utilized this data to create custom interactive graphs with D3. Claude Code stored the scripts for this in the `scripts` folder for later use. Obsidian already has a capable built-in graph view, but with `qmd` and Claude Code, I was able to create custom graphs tailored to my specific interests. The graphs are also highly interactive.
 
 <Image
-  caption="The Obsidian Layout"
+  caption="A custom D3 force-directed graph of the Obsidian vault, with color-coded nodes for Books, Literature Notes, Notes, People, and Quotes"
   src="/assets/images/posts/agentic-note-taking-obsidian-claude-code-d3-visualization.webp"
-  alt="Obsidian Layout"
+  alt="A custom D3 force-directed graph visualization of an Obsidian vault showing interconnected notes as color-coded nodes"
   size="wide"
 />
 


### PR DESCRIPTION
## Summary

- Fixes the `caption` prop on the D3 graph figure, which was incorrectly labeled "The Obsidian Layout"
- Fixes the `alt` text to accurately describe the image for accessibility
- The image shows a custom D3 force-directed graph visualization of the Obsidian vault with color-coded nodes for Books, Literature Notes, Notes, People, and Quotes

## Test plan

- [x] Verify the caption and alt text render correctly on the essay page