### PR TITLE
chore(content): update journal posts and now page for March 2026

### DIFF
--- a/src/content/journal/2025/from-typewriter-to-split-keyboard.mdx
+++ b/src/content/journal/2025/from-typewriter-to-split-keyboard.mdx
@@ -3,7 +3,7 @@ title: From Typewriter to Split Keyboard
 subtitle: How I Fell in Love with Typing
 slug: from-typewriter-to-split-keyboard
 date: 2025-08-04
-updated: 2025-12-19
+updated: 2026-03-25
 author: Stefan Imhoff
 description: Discover my journey from typewriters to mechanical and split keyboards. Learn how typing, layouts, and customization transformed my digital life and workflow.
 cover: "/assets/images/cover/from-typewriter-to-split-keyboard.webp"
@@ -115,7 +115,9 @@ But how do you start learning an entirely different keyboard layout? I read some
 
 I started practicing for 10 minutes each day, and after just one week, I reached a top speed of 37 WPM and unlocked a seventh letter. Even in this short time, I can already say that with Colemak-DH, my fingers move less, and my hands feel more relaxed.
 
-**Update December 2025:** After four months of 10-15 minutes of training, I unlocked all keys and now reached a top speed of 47 wpm and an average of 42 wpm.
+- **Update December 2025:** After four months of 10-15 minutes of training, I unlocked all keys and now reached a top speed of 47 wpm and an average of 42 wpm.
+- **Update January 2026:** I decided to switch my keycaps to Colemak-DH and keep QWERTY as a secondary layer. When I made the switch permanently, my speed dropped to 30 wpm for a few weeks. Using it every day is different from practicing for just a few minutes daily.
+- **Update March 2026:** After using Colemak-DH for nearly three months, my top speed has reached around 70 wpm. I also installed the [keyboard layout](https://github.com/ColemakMods/mod-dh) on my computers to use it when I'm not using my split keyboard.
 
 ## Accuracy First: The Dao of Typing
 

--- a/src/content/journal/2026/agentic-note-taking-obsidian-claude-code.mdx
+++ b/src/content/journal/2026/agentic-note-taking-obsidian-claude-code.mdx
@@ -2,6 +2,7 @@
 title: "Agentic Note-Taking: Transforming My Obsidian Vault with Claude Code"
 slug: agentic-note-taking-obsidian-claude-code
 date: 2026-03-07
+updated: 2026-03-25
 author: Stefan Imhoff
 description: Discover how I used Claude Code to automate and reorganize my Obsidian vault. From implementing Zettelkasten and PARA to cleaning up assets and fetching metadata, see how agentic AI transformed my personal knowledge management.
 cover: /assets/images/cover/agentic-note-taking-obsidian-claude-code.webp
@@ -107,6 +108,8 @@ In my daily notes, I record the books I read, the movies or TV shows I watched, 
 I asked Claude Code to review my daily notes and identify new types of resources. I also requested it to create templates and resources, as well as download the information. For instance, it created a **podcast** type and a **company** type for me, and then it went through my notes to add backlinks.
 
 And all this was just the ideas I came up with and worked on in two sessions of 2-3 hours. Claude constantly wrote down information about my vault and how I work with it in its memory file.
+
+A few weeks later, I created skills for regular maintenance tasks, which you can find in my [skills repository](https://github.com/kogakure/skills).
 
 ## What's Next for My Vault
 

--- a/src/pages/now.mdx
+++ b/src/pages/now.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/PageLayout.astro
 title: Now
-updated: 2026-03-18
+updated: 2026-03-25
 description: This is my Now page, listing the things I currently do.
 intro: This is my Now page, a website with the content of what I am focused on at this point in my life.
 ---
@@ -16,4 +16,4 @@ The concept of a [Now](https://nownownow.com/) page is an idea by [Derek Silvers
 - Playing and improving my code with [Claude Code](https://code.claude.com/)
 - 📝 Creating and reviewing highlights with [Readwise](https://readwise.io/i/stefan805) every day
 - 🗃️ Connecting ideas with the [Zettelkasten](https://grokipedia.com/page/Zettelkasten) note-taking method, using [Obsidian](https://obsidian.md/)
-- 📚 Always reading at least two or three [books](https://www.goodreads.com/kogakure) at the same time
+- 📚 Always reading a few [books](https://www.goodreads.com/kogakure) at the same time


### PR DESCRIPTION
## Summary

- **Split keyboard post**: Added January 2026 update (switched keycaps to Colemak-DH, speed dropped to 30 wpm during transition) and March 2026 update (top speed now ~70 wpm, installed keyboard layout on computers). Also updated the `updated` date to 2026-03-25.
- **Agentic note-taking post**: Added a paragraph mentioning the skills repository created for regular vault maintenance tasks. Updated `updated` date to 2026-03-25.
- **Now page**: Updated date to 2026-03-25 and tweaked the reading blurb wording.

## Test plan

- [x] Verify journal post renders correctly with the new bullet-list update format
- [x] Check the skills repository link resolves correctly
- [x] Confirm now page date and content display as expected