### PR TITLE
feat(analytics): improve umami event labels with context prefixes

### DIFF
--- a/src/components/MainNavigation.astro
+++ b/src/components/MainNavigation.astro
@@ -12,7 +12,7 @@ import navigation from '../data/navigation.json';
 					<li class="mie-[10px] xs:mie-[5px]">
 						<Link
 							class="rounded-2 pli-3 pbe-2 pbs-3 hover:bg-shibui-950/10 focus:bg-shibui-950/10 hover:dark:bg-shibui-50/10 focus:dark:bg-shibui-50/10"
-							data-umami-event={title}
+							data-umami-event={`Main Navigation: ${title}`}
 							href={url}
 						>
 							{title}

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -7,7 +7,7 @@ import Link from '../components/Link.astro';
 	<Link
 		aria-label="Mail"
 		class="flex h-clickarea w-clickarea cursor-pointer items-center justify-center transition-transform duration-500 ease-in-out hover:scale-125 focus:scale-125"
-		data-umami-event="Mail"
+		data-umami-event="Social Icon: Mail"
 		href="#protected-email"
 		title="Mail"
 		data-domain="stefanimhoff"
@@ -20,7 +20,7 @@ import Link from '../components/Link.astro';
 	<Link
 		aria-label="Twitter/X"
 		class="flex h-clickarea w-clickarea cursor-pointer items-center justify-center transition-transform duration-500 ease-in-out hover:scale-125 focus:scale-125"
-		data-umami-event="𝕏"
+		data-umami-event="Social Icon: 𝕏"
 		href="https://x.com/kogakure"
 		title="𝕏"
 	>
@@ -29,7 +29,7 @@ import Link from '../components/Link.astro';
 	<Link
 		aria-label="Instagram"
 		class="flex h-clickarea w-clickarea cursor-pointer items-center justify-center transition-transform duration-500 ease-in-out hover:scale-125 focus:scale-125"
-		data-umami-event="Instagram"
+		data-umami-event="Social Icon: Instagram"
 		href="https://instagram.com/kogakure"
 		title="Instagram"
 	>
@@ -38,7 +38,7 @@ import Link from '../components/Link.astro';
 	<Link
 		aria-label="GitHub"
 		class="flex h-clickarea w-clickarea cursor-pointer items-center justify-center transition-transform duration-500 ease-in-out hover:scale-125 focus:scale-125"
-		data-umami-event="GitHub"
+		data-umami-event="Social Icon: GitHub"
 		href="https://github.com/kogakure"
 		title="GitHub"
 	>

--- a/src/components/Subnavigation.astro
+++ b/src/components/Subnavigation.astro
@@ -12,6 +12,7 @@ import Link from './Link.astro';
 					<Link
 						href={url}
 						class="font-light decoration-4 underline-offset-auto hover:underline hover:decoration-shibui-900/20 focus:underline focus:decoration-shibui-900/20 dark:hover:decoration-shibui-100/20 dark:focus:decoration-shibui-100/20"
+						data-umami-event={`Subnavigation: ${title}`}
 					>
 						{title}
 					</Link>
@@ -26,6 +27,7 @@ import Link from './Link.astro';
 					<Link
 						href={url}
 						class="font-light decoration-4 underline-offset-auto hover:underline hover:decoration-shibui-900/20 focus:underline focus:decoration-shibui-900/20 dark:hover:decoration-shibui-100/20 dark:focus:decoration-shibui-100/20"
+						data-umami-event={`Subnavigation: ${title}`}
 					>
 						{title}
 					</Link>


### PR DESCRIPTION
## Summary

- `MainNavigation`: events now use `Main Navigation: <title>` format
- `Subnavigation`: added missing `data-umami-event` attributes using `Subnavigation: <title>` format (both main and misc link lists)
- `SocialLinks`: events now use `Social Icon: <title>` format

## Test plan

- [x] Verify analytics events fire with the new labels in the browser (check network requests or Umami dashboard)
- [x] Confirm no visual or functional regressions in navigation and social links