### PR TITLE
fix(seo): strip Astro hash from OG image URL in writing posts

### DIFF
--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -91,7 +91,7 @@ const coverOgUrl = entry.data.cover?.src
 			entry.data.cover.src
 				.split('/')
 				.pop()
-				?.replace(/\.[^.]+$/, '.jpg') ?? 'ma.jpg'
+				?.replace(/(?:\.[A-Za-z0-9_-]+)?\.(?:webp|jpe?g|png|avif)$/i, '.jpg') ?? 'ma.jpg'
 		}`
 	: undefined;
 


### PR DESCRIPTION
## Summary

- `entry.data.cover.src` is an Astro-processed path with a content hash (e.g. `guide-to-agentic-coding.C-VXmB65.jpg`)
- Old regex only stripped the final extension, leaving the hash in place → OG URLs 404'd
- `scripts/og-generate.cjs` writes files without hashes, so URLs must match bare `<slug>.jpg`
- New regex strips the optional hash segment + extension in one pass

## Test plan

- [x] Build and confirm `og:image:url` / `twitter:image` on a cover post has no hash (e.g. `/writing/guide-to-agentic-coding/`)
- [x] Verify the resolved URL returns 200 in preview
- [x] Spot-check a post without a cover falls back to `/assets/images/og/ma.jpg`