### PR TITLE
fix(design-system): fix hero title overflow on mobile viewports

### DIFF
--- a/docs/coolify-image-cache.md
+++ b/docs/coolify-image-cache.md
@@ -29,43 +29,23 @@ near the `pnpm run build` step. If the step shows `CACHED`, the cache mount is a
 
 ---
 
-## Strategy 2 — Coolify Persistent Storage (fallback)
+## What does NOT work — Coolify Persistent Storage
 
-Use this only if BuildKit cache mounts are not persisting (e.g. Coolify rebuilds from a fresh runner each time).
+Do not add a Coolify Persistent Storage volume pointing at `/app/node_modules/.astro`.
 
-### Steps
+The multi-stage Dockerfile produces a final `nginx` image. Coolify mounts volumes on the **runtime container** (nginx), not the builder stage. The nginx container never reads or writes `.astro/assets/`, so the volume is dead weight and has no effect on build speed.
 
-1. In Coolify dashboard, open the application.
-2. Go to the **Storages** tab.
-3. Click **+ Add Storage**.
-4. Fill in:
-   - **Type**: Volume Mount
-   - **Name**: `astro-image-cache`
-   - **Mount Path (container)**: `/app/node_modules/.astro`
-5. Click **Save**, then **Redeploy**.
+---
 
-> Use **Volume Mount** (managed by Coolify/Docker), not File Mount or Directory Mount — those are for config files, not build caches.
+## Coolify Resource Limits
 
-### Verify the volume was created
+The resource limits under `Configuration → Resource Limits` apply to the nginx runtime container, not the builder. Keep them either empty or set `Maximum Swap Limit >= Maximum Memory Limit` — Docker's `memory_swap` field is the **combined** memory + swap ceiling. Setting swap lower than memory causes the container to fail to start:
 
-SSH to the VPS and run:
-
-```bash
-docker volume ls | grep astro-image-cache
-du -sh $(docker volume inspect -f '{{ .Mountpoint }}' astro-image-cache_<app-uuid>)
+```
+Error response from daemon: Minimum memoryswap limit should be larger than memory limit
 ```
 
-After the first build the volume directory should contain `.astro/assets/` with subdirectories of optimised images.
-
-### Evict stale cache
-
-If you rename or remove source images, the Sharp cache may serve stale output. Clear it with:
-
-```bash
-docker volume rm <volume-name>
-```
-
-Then redeploy to rebuild from scratch.
+Recommended: leave both `Maximum Memory Limit` and `Maximum Swap Limit` empty. Nginx serving static files uses ~20 MB.
 
 ---
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -78,8 +78,8 @@ const videos = defineCollection({
 	}),
 });
 
-const articles = defineCollection({
-	loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/articles' }),
+const links = defineCollection({
+	loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/links' }),
 	schema: z.object({
 		title: z.string(),
 		url: z.string().url(),
@@ -251,6 +251,6 @@ export const collections = {
 	audiobooks,
 	podcasts,
 	videos,
-	articles,
+	links,
 	organizations,
 };

--- a/src/content/links/libertarianism/anatomy-of-the-state.mdx
+++ b/src/content/links/libertarianism/anatomy-of-the-state.mdx
@@ -1,0 +1,7 @@
+---
+title: Anatomy of the State
+url: https://www.anatomystatefilm.com/
+topic: libertarianism
+language: en
+description: A film based on the book by Murray Rothbard
+---

--- a/src/content/links/libertarianism/atlas-initiative.mdx
+++ b/src/content/links/libertarianism/atlas-initiative.mdx
@@ -2,7 +2,6 @@
 title: Atlas Initiative
 url: https://www.atlas-initiative.de/
 topic: libertarianism
-sort: 60
 language: de
 description: Deutsche Initiative für liberale Ideen und Freiheitsdenken.
 ---

--- a/src/content/links/libertarianism/der-sandwirt.mdx
+++ b/src/content/links/libertarianism/der-sandwirt.mdx
@@ -2,7 +2,6 @@
 title: Der Sandwirt
 url: https://www.dersandwirt.de/
 topic: libertarianism
-sort: 70
 language: de
 description: Das Magazin des konstruktiven Widerstands.
 ---

--- a/src/content/links/libertarianism/fee.mdx
+++ b/src/content/links/libertarianism/fee.mdx
@@ -2,7 +2,6 @@
 title: Foundation for Economic Education (FEE)
 url: https://fee.org/
 topic: libertarianism
-sort: 20
 language: en
 description: Making the case for freedom, free markets, and free people since 1946.
 ---

--- a/src/content/links/libertarianism/free-the-people.mdx
+++ b/src/content/links/libertarianism/free-the-people.mdx
@@ -2,7 +2,6 @@
 title: Free the People
 url: https://freethepeople.org/
 topic: libertarianism
-sort: 40
 language: en
 description: Making the values of liberty entertaining, accessible, and human.
 ---

--- a/src/content/links/libertarianism/freiheitsfunken.mdx
+++ b/src/content/links/libertarianism/freiheitsfunken.mdx
@@ -2,7 +2,6 @@
 title: Freiheitsfunken
 url: https://freiheitsfunken.info/
 topic: libertarianism
-sort: 90
 language: en
 description: Libertäre Glücksschmiede
 ---

--- a/src/content/links/libertarianism/hard-money-wtf-happened-in-1971.mdx
+++ b/src/content/links/libertarianism/hard-money-wtf-happened-in-1971.mdx
@@ -1,0 +1,6 @@
+---
+title: Hard Money – WTF Happened in 1971?
+url: https://www.hardmoneyfilm.com/
+topic: libertarianism
+language: en
+---

--- a/src/content/links/libertarianism/libertarianism-org.mdx
+++ b/src/content/links/libertarianism/libertarianism-org.mdx
@@ -2,7 +2,6 @@
 title: Libertarianism.org
 url: https://www.libertarianism.org/
 topic: libertarianism
-sort: 50
 language: en
 description: Cato Institute's resource for libertarian philosophy and policy.
 ---

--- a/src/content/links/libertarianism/mises-institute.mdx
+++ b/src/content/links/libertarianism/mises-institute.mdx
@@ -2,7 +2,6 @@
 title: Mises Institute
 url: https://mises.org/
 topic: libertarianism
-sort: 10
 language: en
 description: The world's leading provider of libertarian and Austrian economics education and research.
 ---

--- a/src/content/links/libertarianism/mises-wire.mdx
+++ b/src/content/links/libertarianism/mises-wire.mdx
@@ -2,7 +2,6 @@
 title: Mises Wire
 url: https://mises.org/wire
 topic: libertarianism
-sort: 10
 language: en
 description: Contemporary news and opinion through the lens of Austrian economics and libertarian political economy.
 ---

--- a/src/content/links/libertarianism/petrodollars.mdx
+++ b/src/content/links/libertarianism/petrodollars.mdx
@@ -1,0 +1,7 @@
+---
+title: Petrodollars
+url: https://www.petrodollarsfilm.com/
+topic: libertarianism
+language: en
+description: A documentary based on the article 'The Hidden Costs of the Petrodollar System' by Alex Gladstein.
+---

--- a/src/content/links/libertarianism/reason.mdx
+++ b/src/content/links/libertarianism/reason.mdx
@@ -2,7 +2,6 @@
 title: Reason – Free Minds and Free Markets
 url: https://reason.com/
 topic: libertarianism
-sort: 30
 language: en
 description: The leading libertarian magazine covering politics, culture, and ideas.
 ---

--- a/src/content/links/libertarianism/wtf-happened-in-1971.mdx
+++ b/src/content/links/libertarianism/wtf-happened-in-1971.mdx
@@ -1,0 +1,6 @@
+---
+title: WTF Happened in 1971?
+url: https://wtfhappenedin1971.com/
+topic: libertarianism
+language: en
+---

--- a/src/content/videos/libertarianism/anatomy-of-the-state.mdx
+++ b/src/content/videos/libertarianism/anatomy-of-the-state.mdx
@@ -1,0 +1,11 @@
+---
+title: Anatomy of the State
+url: https://www.youtube.com/watch?v=Dg2oPakq_gE
+topic: libertarianism
+sort: 1050
+language: en
+youtubeId: Dg2oPakq_gE
+featured: true
+description: A film based on the book by Murray Rothbard
+kind: video
+---

--- a/src/content/videos/libertarianism/hard-money-wft-happened-in-1971.mdx
+++ b/src/content/videos/libertarianism/hard-money-wft-happened-in-1971.mdx
@@ -1,0 +1,11 @@
+---
+title: Hard Money – WTF Happened in 1971?
+url: https://www.youtube.com/watch?v=hX9e1VSSP6Y
+topic: libertarianism
+sort: 1045
+language: en
+youtubeId: hX9e1VSSP6Y
+featured: true
+description: WTF happened in 1971?
+kind: video
+---

--- a/src/content/videos/libertarianism/petrodollars.mdx
+++ b/src/content/videos/libertarianism/petrodollars.mdx
@@ -1,0 +1,11 @@
+---
+title: Petrodollars
+url: https://www.youtube.com/watch?v=_NNmCXa6rjU
+topic: libertarianism
+sort: 1045
+language: en
+youtubeId: _NNmCXa6rjU
+featured: true
+description: A documentary based on the article 'The Hidden Costs of the Petrodollar System' by Alex Gladstein.
+kind: video
+---

--- a/src/layouts/DesignSystemLayout.astro
+++ b/src/layouts/DesignSystemLayout.astro
@@ -37,7 +37,7 @@ const orderStr = order !== undefined && order > 0 ? String(order).padStart(2, '0
 		>
 			{
 				orderStr && (
-					<div class="col-span-1 flex flex-col gap-1 xl:col-span-1 xl:col-start-1">
+					<div class="col-span-3 flex flex-row items-baseline gap-2 md:col-span-1 md:flex-col md:gap-1 xl:col-span-1 xl:col-start-1">
 						<span class="text-hai font-mono text-xs uppercase tracking-wider">
 							{orderStr}
 						</span>
@@ -54,8 +54,8 @@ const orderStr = order !== undefined && order > 0 ? String(order).padStart(2, '0
 			}
 			<div
 				class:list={[
-					'col-span-2 md:col-span-5 xl:col-span-9',
-					orderStr ? 'xl:col-start-2' : 'col-span-3 xl:col-span-10 xl:col-start-2',
+					'col-span-3 md:col-span-5 xl:col-span-9',
+					orderStr ? 'xl:col-start-2' : 'xl:col-span-10 xl:col-start-2',
 				]}
 			>
 				<Title className="text-7 mbe-3 leading-none">{title}</Title>

--- a/src/pages/libertarianism.astro
+++ b/src/pages/libertarianism.astro
@@ -32,19 +32,19 @@ type Books = CollectionEntry<'books'>;
 type Audiobooks = CollectionEntry<'audiobooks'>;
 type Podcasts = CollectionEntry<'podcasts'>;
 type Videos = CollectionEntry<'videos'>;
-type Articles = CollectionEntry<'articles'>;
+type Links = CollectionEntry<'links'>;
 type Organizations = CollectionEntry<'organizations'>;
 
 const topic = 'libertarianism';
 const byTopic = (entry: { data: { topic: string } }) => entry.data.topic === topic;
 
-const [books, audiobooks, podcasts, videos, publications, organizations] = (
+const [books, audiobooks, podcasts, videos, links, organizations] = (
 	await Promise.all([
 		getCollection('books', byTopic),
 		getCollection('audiobooks', byTopic),
 		getCollection('podcasts', byTopic),
 		getCollection('videos', byTopic),
-		getCollection('articles', byTopic),
+		getCollection('links', byTopic),
 		getCollection('organizations', byTopic),
 	])
 ).map((group) => [...group].sort(sortBySortKey)) as [
@@ -52,7 +52,7 @@ const [books, audiobooks, podcasts, videos, publications, organizations] = (
 	Audiobooks[],
 	Podcasts[],
 	Videos[],
-	Articles[],
+	Links[],
 	Organizations[],
 ];
 
@@ -244,15 +244,15 @@ const description =
 		}
 
 		{
-			publications.length > 0 && (
+			links.length > 0 && (
 				<Reveal client:visible>
-					<PageSection label="Publications">
+					<PageSection label="Links">
 						<UnorderedList>
-							{publications.map((pub) => (
+							{links.map((link) => (
 								<ListItem>
-									<TextLink href={pub.data.url}>{pub.data.title}</TextLink>
-									{pub.data.description && (
-										<span class="text-hai"> — {pub.data.description}</span>
+									<TextLink href={link.data.url}>{link.data.title}</TextLink>
+									{link.data.description && (
+										<span class="text-hai"> — {link.data.description}</span>
 									)}
 								</ListItem>
 							))}

--- a/src/pages/tools.mdx
+++ b/src/pages/tools.mdx
@@ -14,7 +14,7 @@ export const components = mapping;
 - [Capisco Chair by HÅG](https://www.fully.com/chairs/for-standing-desks/hag-capisco-chair.html) –
   black leather and a black frame
 - [Black Leather Desk Pad](https://www.amazon.de/dp/B07GSC21K8) – 90×50 cm
-- [MacBook Stand](https://www.amazon.de/dp/B01F01DRW6) – my MacBook Pro 15" rests on a silver aluminum stand. I usually don’t type on the build-in keyboard, but on a mechanical keyboard. For me my MacBook is a second screen.
+- [MacBook Stand](https://www.amazon.de/dp/B01F01DRW6) – my MacBook Pro 14" rests on a silver aluminum stand. I usually don’t type on the build-in keyboard, but on a mechanical keyboard. For me my MacBook is a second screen.
 - [BenQ Screenbar Plus](https://www.amazon.de/dp/B07GGVNXSW) – fantastic light for the table without blending
 
 ## Tech


### PR DESCRIPTION
## Summary

- On narrow viewports (320–390px) the design system hero strip placed the order number and kanji in column 1, leaving only 2 of 3 columns for the large display title — causing it to clip outside the viewport.
- Meta block (number + kanji) now spans full width as a flex row on mobile and reverts to its single-column vertical stack at `md:` breakpoint.
- Title gets the full 3-column grid width on mobile; `md:`/`xl:` layout unchanged.
- Minor: corrects MacBook model from 15" to 14" in `tools.mdx`.

## Test plan

- [x] Open `/design-system/typography/` at 320, 360, 390px — `05` and `字` appear on one line above `Typography`, no horizontal scroll
- [x] Check longer titles: `/design-system/layout-grids/`, `/design-system/brand-foundations/`
- [x] Tablet (768px): side-by-side meta + title layout intact
- [x] Desktop (1280px+): layout unchanged