### PR TITLE
feat(config): add graphify knowledge graph integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: knowledge graph at graphify-out/. For focused questions, run `graphify query \\\"<question>\\\"` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context.\"}}'   || true ;; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HIT=$(python3 -c \"import json,sys;d=json.load(sys.stdin);t=d.get('tool_input',d);s=(str(t.get('file_path') or '')+' '+str(t.get('pattern') or '')+' '+str(t.get('path') or '')).lower().replace(chr(92),'/');exts=('.py','.js','.ts','.tsx','.jsx','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.lua','.sh','.md','.rst','.txt','.mdx');sys.stdout.write('1' if 'graphify-out/' not in s and any(e in s for e in exts) else '')\" 2>/dev/null || true); if [ \"$HIT\" = 1 ] && [ -f graphify-out/graph.json ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: knowledge graph at graphify-out/. For codebase questions, run `graphify query \\\"<question>\\\"` (scoped subgraph, usually much smaller than reading files one by one), `graphify explain \\\"<concept>\\\"`, or `graphify path \\\"<A>\\\" \\\"<B>\\\"`, instead of reading source files to answer. Read raw files to modify or debug specific code, or when the graph lacks the detail.\"}}'; fi || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/kogakure/.local/share/../bin/graphify hook-check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    ".opencode/plugins/graphify.js"
+  ]
+}

--- a/.opencode/plugins/graphify.js
+++ b/.opencode/plugins/graphify.js
@@ -1,0 +1,22 @@
+// graphify OpenCode plugin
+// Injects a knowledge graph reminder before bash tool calls when the graph exists.
+import { existsSync } from "fs";
+import { join } from "path";
+
+export const GraphifyPlugin = async ({ directory }) => {
+  let reminded = false;
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (reminded) return;
+      if (!existsSync(join(directory, "graphify-out", "graph.json"))) return;
+
+      if (input.tool === "bash") {
+        output.args.command =
+          'echo "[graphify] knowledge graph at graphify-out/. For focused questions, run \`graphify query \"<question>\"\` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context." && ' +
+          output.args.command;
+        reminded = true;
+      }
+    },
+  };
+};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,17 @@ Personal website and blog for Stefan Imhoff, featuring writing posts, haiku coll
 - Development Notes (`docs/development-notes.md`) – Special knowledge for development
 - Content Collections (`docs/content-collections.md`) – Which Astro content collections exist?
 - Build Features (`docs/build-features.md`) – Important information on building the site
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+
+Rules:
+
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,12 @@
 @AGENTS.md
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,6 @@ export default [
 		},
 	},
 	{
-		ignores: ['public/assets/scripts/'],
+		ignores: ['public/assets/scripts/', '.opencode/', '.codex/'],
 	},
 ];

--- a/src/pages/now.mdx
+++ b/src/pages/now.mdx
@@ -15,7 +15,7 @@ The concept of a [Now](https://nownownow.com/) page is an idea by [Derek Silvers
 
 ## What I'm Doing
 
-- Starting a new job where I build a design system, take over the UI strategy, and implement UIs.
+- Planning an agentic strategy for my company and start building a design system, take over the UI strategy, and implement UIs.
 - Building this website anew with a new design, layouts, a custom design system, and lots of agentic engineering.
 - Learning Japanese and Spanish on [Duolingo](https://www.duolingo.com/profile/kogakure) and with [Anki](https://apps.ankiweb.net/)
 - Learning to type on my new [ZSA Voyager](https://www.zsa.io/voyager) split keyboard and at the same time learning to type [Colemak Mod-DH](https://colemakmods.github.io/mod-dh/) keyboard layout


### PR DESCRIPTION
## Summary

- Add graphify tool hooks for Claude Code (`.claude/settings.json`), Codex (`.codex/hooks.json`), and OpenCode (`.opencode/`)
- Update `AGENTS.md` and `CLAUDE.md` with graphify usage rules for codebase navigation
- Exclude `.opencode/` and `.codex/` dirs from ESLint to avoid tsconfig scope errors

## Test plan

- [ ] Verify ESLint passes: `pnpm lint`
- [ ] Verify graphify hooks trigger correctly during Claude Code sessions