### PR TITLE
fix(flag): add dark mode text color to Flag component

### DIFF
--- a/src/components/ui/Flag.tsx
+++ b/src/components/ui/Flag.tsx
@@ -8,7 +8,7 @@ interface Props extends HTMLAttributes<HTMLElement> {
 }
 
 const flagClasses =
-	'rounded-1 border-1 border-solid border-usuzumi bg-kiri font-mono text-[0.7em] text-black decoration-0 pli-[0.3em] pbe-0 pbs-[0.1em] dark:bg-yoru/80';
+	'rounded-1 border-1 border-solid border-usuzumi bg-kiri font-mono text-[0.7em] text-black decoration-0 pli-[0.3em] pbe-0 pbs-[0.1em] dark:bg-yoru/80 dark:text-washi';
 
 export const Flag = ({ className, href, label, ...props }: Props) => {
 	const inner = (


### PR DESCRIPTION
## Summary

* Flag component had `text-black` with no dark mode override, making text invisible on dark backgrounds
* Added `dark:text-washi` to match the pattern used in Badge and other components

## Test plan

- [X] Visit `/design-system/components/` in dark mode
- [X] Verify Flag component text is visible

Closes [SI-52](https://linear.app/kogakure/issue/SI-52/flag-component-text-color-issue-in-dark-mode)