### PR TITLE
fix(design-system): use dark mode text token for ColorSwatchMini labels

### DIFF
--- a/src/pages/design-system/components/index.astro
+++ b/src/pages/design-system/components/index.astro
@@ -658,10 +658,7 @@ const sampleBookImg = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http
 		description="Inline 16×16 color chip. Used within text or dense tables."
 		props={[{ name: 'color', type: 'string', description: 'Hex color value' }]}
 	>
-		<p
-			class="flex flex-wrap items-center gap-3 font-mono text-sm"
-			style="color: var(--color-sumi)"
-		>
+		<p class="flex flex-wrap items-center gap-3 font-mono text-sm text-sumi dark:text-washi">
 			<span class="flex items-center gap-1.5"><ColorSwatchMini color="#900B20" /> Beni</span>
 			<span class="flex items-center gap-1.5"
 				><ColorSwatchMini color="#B83A4E" /> Beni Light</span


### PR DESCRIPTION
## Summary

* Replace hardcoded `style="color: var(--color-sumi)"` with `text-sumi dark:text-washi` Tailwind classes on the ColorSwatchMini showcase in the design system page
* `--color-sumi` is near-black (#0E0D0C) — invisible on dark backgrounds
* Pattern matches existing design system components (e.g. Badge)

Closes [SI-51](https://linear.app/kogakure/issue/SI-51/text-colors-in-dark-mode-are-not-visible)

## Test plan

- [X] Visit `/design-system/components/` in dark mode
- [X] Verify ColorSwatchMini label text (Beni, Beni Light, etc.) is readable
- [X] Verify light mode still looks correct