### PR TITLE
feat(ui): replace paid Badge with 💰 emoji icon

### DIFF
--- a/src/components/content/AudioCard.tsx
+++ b/src/components/content/AudioCard.tsx
@@ -91,7 +91,11 @@ export const AudioCard = ({
 				{(featured || paid || language) && (
 					<div className="flex flex-wrap gap-1">
 						{featured && <Badge variant="favorite">Favorite</Badge>}
-						{paid && <Badge variant="paid">Paid</Badge>}
+						{paid && (
+								<span role="img" aria-label="Paid">
+									💰<span className="sr-only">Paid</span>
+								</span>
+							)}
 						{language && <Badge variant="language">{language.toUpperCase()}</Badge>}
 					</div>
 				)}

--- a/src/components/content/BookCard.tsx
+++ b/src/components/content/BookCard.tsx
@@ -91,7 +91,11 @@ export const BookCard = ({
 				{(featured || paid || language) && (
 					<div className="flex flex-wrap gap-1">
 						{featured && <Badge variant="favorite">Favorite</Badge>}
-						{paid && <Badge variant="paid">Paid</Badge>}
+						{paid && (
+								<span role="img" aria-label="Paid">
+									💰<span className="sr-only">Paid</span>
+								</span>
+							)}
 						{language && <Badge variant="language">{language.toUpperCase()}</Badge>}
 					</div>
 				)}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import { cn } from '../../lib/utils';
 
-type Variant = 'default' | 'favorite' | 'paid' | 'language';
+type Variant = 'default' | 'favorite' | 'language';
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {
 	variant?: Variant;
@@ -11,7 +11,6 @@ const variantClasses: Record<Variant, string> = {
 	default: 'bg-kiri text-sumi border-usuzumi dark:bg-sumi dark:text-washi dark:border-nezumi',
 	favorite:
 		'bg-beni-pale text-beni border-beni/25 dark:bg-beni-light/15 dark:text-beni-light dark:border-beni-light/30',
-	paid: 'bg-kiri text-nezumi border-usuzumi dark:bg-sumi dark:text-usuzumi dark:border-nezumi',
 	language:
 		'bg-kiri text-nezumi border-usuzumi dark:bg-sumi dark:text-usuzumi dark:border-nezumi',
 };

--- a/src/pages/design-system/components/index.astro
+++ b/src/pages/design-system/components/index.astro
@@ -371,11 +371,11 @@ const sampleBookImg = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http
 		name="Badge"
 		importPath="components/ui/Badge"
 		category="ui"
-		description="Small status/label chip. Variants: default, favorite (Beni), paid, language."
+		description="Small status/label chip. Variants: default, favorite (Beni), language."
 		props={[
 			{
 				name: 'variant',
-				type: '"default" | "favorite" | "paid" | "language"',
+				type: '"default" | "favorite" | "language"',
 				default: '"default"',
 				description: 'Visual variant',
 			},
@@ -384,7 +384,6 @@ const sampleBookImg = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http
 		<div class="flex flex-wrap gap-2">
 			<Badge>Default</Badge>
 			<Badge variant="favorite">Favorite</Badge>
-			<Badge variant="paid">Paid</Badge>
 			<Badge variant="language">DE</Badge>
 		</div>
 	</ComponentShowcase>
@@ -701,7 +700,7 @@ const sampleBookImg = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http
 		name="AudioCard"
 		importPath="components/content/AudioCard"
 		category="content"
-		description="Card for audiobooks and podcasts. Cover image with placeholder icon fallback. Badges for featured/paid/language."
+		description="Card for audiobooks and podcasts. Cover image with placeholder icon fallback. Badges for featured/language; paid shown as 💰 emoji."
 		props={[
 			{ name: 'title', type: 'string', description: 'Card title (required)' },
 			{
@@ -713,7 +712,7 @@ const sampleBookImg = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http
 			{ name: 'moderator', type: 'string', description: 'Podcast host' },
 			{ name: 'cover', type: 'string', description: 'Cover image URL' },
 			{ name: 'featured', type: 'boolean', description: 'Shows Favorite badge' },
-			{ name: 'paid', type: 'boolean', description: 'Shows Paid badge' },
+			{ name: 'paid', type: 'boolean', description: 'Shows 💰 emoji with sr-only "Paid" label' },
 			{ name: 'language', type: 'string', description: 'Shows language badge' },
 			{
 				name: 'links',


### PR DESCRIPTION
## Summary

* Replace `Badge variant="paid"` in `BookCard` and `AudioCard` with `💰` emoji wrapped in `<span role="img" aria-label="Paid">` plus a `sr-only` "Paid" label for screen readers
* Remove unused `paid` variant from `Badge` component
* Update design system docs to reflect the change

## Test plan

- [X] Verify 💰 emoji appears on paid items on `/libertarianism/`
- [X] Verify no "Paid" badge/chip renders anymore
- [X] Check screen reader announces "Paid" (via `aria-label` + `sr-only`)
- [X] Confirm design system page no longer shows paid Badge variant
- [X] All 416 tests pass

Closes [SI-53](https://linear.app/kogakure/issue/SI-53/replace-paid-tag-with-money-icon-and-screen-reader-label)