### PR TITLE
chore: convert CLAUDE.md to symlink, bump pnpm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,1 @@
-@AGENTS.md
-
-## graphify
-
-This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
-
-Rules:
-
-- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
-- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
-- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+AGENTS.md

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "astro-stefanimhoff.de",
 	"type": "module",
 	"version": "2.0.0",
-	"packageManager": "pnpm@11.1.2",
+	"packageManager": "pnpm@11.8.0",
 	"scripts": {
 		"astro": "astro",
 		"build": "astro build",


### PR DESCRIPTION
## Summary
- Replace CLAUDE.md content with a symlink to AGENTS.md so both files stay in sync.
- Bump packageManager pin from pnpm@11.1.2 to pnpm@11.8.0.

## Test plan
- [ ] Verify Claude Code / agents still pick up instructions via the symlinked CLAUDE.md
- [ ] Run `pnpm install` to confirm pnpm 11.8.0 resolves cleanly