### PR TITLE
Update Tools page (SI-67)

### DIFF
--- a/src/pages/tools.mdx
+++ b/src/pages/tools.mdx
@@ -37,14 +37,16 @@ export const components = mapping;
 
 ## Development
 
-- [Zed](https://zed.dev/) – I use this editor now more often than Neovim
-- [Neovim](https://neovim.io/) – with [LazyVim](https://www.lazyvim.org/) as a plugin manager
+- [Neovim](https://neovim.io/) – my primary editor, with [LazyVim](https://www.lazyvim.org/) as configuration
+- [Doom Emacs](https://github.com/doomemacs/doomemacs) – learning it on the side
+- [Zed](https://zed.dev/) – my second editor
+- [Herdr](https://herdr.dev/) – agentic multiplexer with splits (replaced tmux)
 - [Ghostty](https://ghostty.org/) – terminal emulator
-- [Tmux](https://tmux.github.io/) – terminal multiplexer
 - [LazyGit](https://github.com/jesseduffield/lazygit) – terminal Git client
 - [Claude Code](https://claude.com/product/claude-code) – Agentic coding with Anthropic’s models
 - [Codex](https://openai.com/codex/) – Agentic coding with OpenAI’s models
 - [OpenCode](https://opencode.ai/) – Fantastic open-source TUI with access to nearly all providers and models
+- [Grok](https://grok.com/) – Agentic coding with SpaceXAI’s models
 - [Pi Agent](https://pi.dev) – Still learning it, but it is starting to become my favorite coding agent; a pity Anthropic disallows using their subscription with external agents
 
 ## Design


### PR DESCRIPTION
## Summary

* Neovim + LazyVim now primary editor; Zed demoted to second editor
* Herdr (agentic multiplexer with splits) replaces tmux
* Added Doom Emacs (learning it on the side)
* Added Grok (SpaceXAI) as agent, between OpenCode and Pi
* All tools link to primary source

Closes [SI-67](https://linear.app/kogakure/issue/SI-67/update-tools-page)

## Test plan

- [X] `prettier --check` passes on src/pages/tools.mdx
- [X] Visual check of /tools page Development section